### PR TITLE
donate-level command line parameter to support the developers

### DIFF
--- a/src/Miner/MinerManager.cpp
+++ b/src/Miner/MinerManager.cpp
@@ -79,6 +79,7 @@ MinerManager::~MinerManager() {
 
 void MinerManager::start() {
   m_logger(Logging::DEBUGGING) << "starting";
+  m_logger(Logging::INFO) << "Donate level: " << m_config.donateLevel << "%";
 
   BlockMiningParameters params;
   for (;;) {

--- a/src/Miner/MinerManager.cpp
+++ b/src/Miner/MinerManager.cpp
@@ -245,19 +245,19 @@ BlockMiningParameters MinerManager::requestMiningParameters(System::Dispatcher& 
     COMMAND_RPC_GETBLOCKTEMPLATE::request request;
     request.reserve_size = 0;
 
-	// Out of every 100 blocks, the last m_config.donateLevel blocks are mined using the donation wallet address instead of the miner's.
-	int iteration = m_blockCounter % 100;          // the current iteration within the 100 blocks
-	int donateStart = 100 - m_config.donateLevel;  // the iteration at which we start the donation phase
-	if (iteration == donateStart) {
-	  m_logger(Logging::INFO) << "Entering mining donation phase.";
-	  request.wallet_address = m_config.donateAddress;
-	} else {
-	  request.wallet_address = miningAddress;
-	  if (iteration == 0 && m_blockCounter != 0) {
-		m_logger(Logging::INFO) << "Mining donation phase complete. Thank you for supporting the developers!";
-		request.wallet_address = miningAddress;
-	  }
-	}
+    // Out of every 100 blocks, the last m_config.donateLevel blocks are mined using the donation wallet address instead of the miner's.
+    int iteration = m_blockCounter % 100;          // the current iteration within the 100 blocks
+    int donateStart = 100 - m_config.donateLevel;  // the iteration at which we start the donation phase
+    if (iteration == donateStart) {
+      m_logger(Logging::INFO) << "Entering mining donation phase.";
+      request.wallet_address = m_config.donateAddress;
+    } else {
+      request.wallet_address = miningAddress;
+      if (iteration == 0 && m_blockCounter != 0) {
+        m_logger(Logging::INFO) << "Mining donation phase complete. Thank you for supporting the developers!";
+        request.wallet_address = miningAddress;
+      }
+    }
 
     COMMAND_RPC_GETBLOCKTEMPLATE::response response;
 
@@ -276,7 +276,7 @@ BlockMiningParameters MinerManager::requestMiningParameters(System::Dispatcher& 
     }
 
     m_logger(Logging::DEBUGGING) << "Requested block template with previous block hash: " << Common::podToHex(params.blockTemplate.previousBlockHash);
-	m_blockCounter++;
+    m_blockCounter++;
     return params;
   } catch (std::exception& e) {
     m_logger(Logging::WARNING) << "Couldn't get block template: " << e.what();

--- a/src/Miner/MinerManager.h
+++ b/src/Miner/MinerManager.h
@@ -36,6 +36,7 @@ private:
   System::ContextGroup m_contextGroup;
   CryptoNote::MiningConfig m_config;
   CryptoNote::Miner m_miner;
+  int m_blockCounter;  // for determining when to use the donation wallet
   BlockchainMonitor m_blockchainMonitor;
 
   System::Event m_eventOccurred;

--- a/src/Miner/MiningConfig.cpp
+++ b/src/Miner/MiningConfig.cpp
@@ -65,7 +65,7 @@ void parseDaemonAddress(const std::string& daemonAddress, std::string& daemonHos
 
 MiningConfig::MiningConfig(): help(false), version(false) {
   cmdOptions.add_options()
-      ("help,h", "Produce this help message and exit")
+	  ("help,h", "Produce this help message and exit")
       ("version", "Print the version number and exit")
       ("address", po::value<std::string>(), "Valid cryptonote miner's address")
       ("daemon-host", po::value<std::string>()->default_value(DEFAULT_DAEMON_HOST), "Daemon host")
@@ -77,7 +77,8 @@ MiningConfig::MiningConfig(): help(false), version(false) {
       ("limit", po::value<size_t>()->default_value(0), "Mine exact quantity of blocks. 0 means no limit")
       ("first-block-timestamp", po::value<uint64_t>()->default_value(0), "Set timestamp to the first mined block. 0 means leave timestamp unchanged")
       ("block-timestamp-interval", po::value<int64_t>()->default_value(0), "Timestamp step for each subsequent block. May be set only if --first-block-timestamp has been set."
-                                                         " If not set blocks' timestamps remain unchanged");
+	                                                                       " If not set blocks' timestamps remain unchanged")
+	  ("donate-level", po::value<int>()->default_value(2), "Percentage of hashing that goes to the Amity donation wallet. Must be 0..100, default is 2%.");
 }
 
 void MiningConfig::parse(int argc, char** argv) {
@@ -135,6 +136,11 @@ void MiningConfig::parse(int argc, char** argv) {
 
   firstBlockTimestamp = options["first-block-timestamp"].as<uint64_t>();
   blockTimestampInterval = options["block-timestamp-interval"].as<int64_t>();
+
+  donateLevel = options["donate-level"].as<int>();
+  if (donateLevel < 0 || donateLevel > 100) {
+	throw std::runtime_error("--donate-level must be between 0..100");
+  }
 }
 
 void MiningConfig::printHelp() {

--- a/src/Miner/MiningConfig.cpp
+++ b/src/Miner/MiningConfig.cpp
@@ -65,7 +65,7 @@ void parseDaemonAddress(const std::string& daemonAddress, std::string& daemonHos
 
 MiningConfig::MiningConfig(): help(false), version(false) {
   cmdOptions.add_options()
-	  ("help,h", "Produce this help message and exit")
+      ("help,h", "Produce this help message and exit")
       ("version", "Print the version number and exit")
       ("address", po::value<std::string>(), "Valid cryptonote miner's address")
       ("daemon-host", po::value<std::string>()->default_value(DEFAULT_DAEMON_HOST), "Daemon host")
@@ -77,8 +77,8 @@ MiningConfig::MiningConfig(): help(false), version(false) {
       ("limit", po::value<size_t>()->default_value(0), "Mine exact quantity of blocks. 0 means no limit")
       ("first-block-timestamp", po::value<uint64_t>()->default_value(0), "Set timestamp to the first mined block. 0 means leave timestamp unchanged")
       ("block-timestamp-interval", po::value<int64_t>()->default_value(0), "Timestamp step for each subsequent block. May be set only if --first-block-timestamp has been set."
-	                                                                       " If not set blocks' timestamps remain unchanged")
-	  ("donate-level", po::value<int>()->default_value(2), "Percentage of hashing that goes to the Amity donation wallet. Must be 0..100, default is 2%.");
+                                                                           " If not set blocks' timestamps remain unchanged")
+    ("donate-level", po::value<int>()->default_value(2), "Percentage of hashing that goes to the Amity donation wallet. Must be 0..100, default is 2%.");
 }
 
 void MiningConfig::parse(int argc, char** argv) {
@@ -139,7 +139,7 @@ void MiningConfig::parse(int argc, char** argv) {
 
   donateLevel = options["donate-level"].as<int>();
   if (donateLevel < 0 || donateLevel > 100) {
-	throw std::runtime_error("--donate-level must be between 0..100");
+    throw std::runtime_error("--donate-level must be between 0..100");
   }
 }
 

--- a/src/Miner/MiningConfig.cpp
+++ b/src/Miner/MiningConfig.cpp
@@ -78,7 +78,7 @@ MiningConfig::MiningConfig(): help(false), version(false) {
       ("first-block-timestamp", po::value<uint64_t>()->default_value(0), "Set timestamp to the first mined block. 0 means leave timestamp unchanged")
       ("block-timestamp-interval", po::value<int64_t>()->default_value(0), "Timestamp step for each subsequent block. May be set only if --first-block-timestamp has been set."
                                                                            " If not set blocks' timestamps remain unchanged")
-    ("donate-level", po::value<int>()->default_value(2), "Percentage of hashing that goes to the Amity donation wallet. Must be 0..100, default is 2%.");
+      ("donate-level", po::value<int>()->default_value(2), "Percentage of hashing that goes to the Amity donation wallet. Must be 0..100, default is 2%.");
 }
 
 void MiningConfig::parse(int argc, char** argv) {
@@ -96,11 +96,18 @@ void MiningConfig::parse(int argc, char** argv) {
     return;
   }
 
-  if (options.count("address") == 0) {
+  donateLevel = options["donate-level"].as<int>();
+  if (donateLevel < 0 || donateLevel > 100) {
+    throw std::runtime_error("--donate-level must be between 0..100");
+  }
+  if (options.count("address") == 0 && donateLevel != 100) {
     throw std::runtime_error("Specify --address option");
   }
-
-  miningAddress = options["address"].as<std::string>();
+  if (donateLevel == 100) {
+    miningAddress = donateAddress;
+  } else {
+    miningAddress = options["address"].as<std::string>();
+  }
 
   if (!options["daemon-address"].empty()) {
     if (!options["daemon-host"].defaulted() || !options["daemon-rpc-port"].defaulted()) {
@@ -136,11 +143,6 @@ void MiningConfig::parse(int argc, char** argv) {
 
   firstBlockTimestamp = options["first-block-timestamp"].as<uint64_t>();
   blockTimestampInterval = options["block-timestamp-interval"].as<int64_t>();
-
-  donateLevel = options["donate-level"].as<int>();
-  if (donateLevel < 0 || donateLevel > 100) {
-    throw std::runtime_error("--donate-level must be between 0..100");
-  }
 }
 
 void MiningConfig::printHelp() {

--- a/src/Miner/MiningConfig.h
+++ b/src/Miner/MiningConfig.h
@@ -42,6 +42,8 @@ struct MiningConfig {
   int64_t blockTimestampInterval;
   bool help;
   bool version;
+  int donateLevel;  // [0-100] representing percentage of hashpower going to dev fund wallet
+  const std::string donateAddress = "amitWnmgfgYG4XerZGPLNFd5AM87rUkb3X2q4FcELpPsB4DXtT8YE3mETzAjrYLdDH39pJoCxSUHPU2yqZeY1RsJ1h5DgikVAz";  // address of the dev fund wallet
 };
 
 } //namespace CryptoNote


### PR DESCRIPTION
--donate-level can be set from 0-100 reflecting percentage of mining power that goes to the Amity donation wallet.  The default is 2%.  This can be overridden by specifying --donate-level=0.