### PR TITLE
suppress donation phase ending message when donation phase is disabled

### DIFF
--- a/src/Miner/MinerManager.cpp
+++ b/src/Miner/MinerManager.cpp
@@ -261,7 +261,7 @@ BlockMiningParameters MinerManager::requestMiningParameters(System::Dispatcher& 
       request.wallet_address = m_config.donateAddress;
     } else {
       request.wallet_address = miningAddress;
-      if (iteration == 0 && m_blockCounter != 0) {
+      if (iteration == 0 && m_blockCounter != 0 && m_config.donateLevel != 0) {
         m_logger(Logging::INFO) << "Mining donation phase complete. Thank you for supporting the developers!";
         request.wallet_address = miningAddress;
       }


### PR DESCRIPTION
The miner currently prints "Mining donation phase complete. Thank you for supporting the developers!" even when --donate-level=0, which is confusing since the donation phase never starts.  This PR fixes this issue.